### PR TITLE
Refine hero layout and dropdown styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,13 @@
 /* Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body, h1, h2, h3, p, ul, li {
   margin: 0;
   padding: 0;
-  box-sizing: border-box;
 }
 
 body {

--- a/css/style.css
+++ b/css/style.css
@@ -10,6 +10,7 @@ body {
   line-height: 1.6;
   color: #333;
   padding-top: 80px;   /* prevent content hiding behind fixed header */
+  background-color: #fafafa;
 }
 
 /* Header */
@@ -21,9 +22,10 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 15px 20px;
+  padding: 15px 32px;
   background: #fff;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid #e4e4e4;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
   z-index: 1000;
 }
 
@@ -31,16 +33,53 @@ header {
   max-height: 50px;
 }
 
+.language-selector {
+  position: relative;
+}
+
 .language-selector select {
-  padding: 5px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 8px 42px 8px 14px;
   font-size: 1rem;
+  font-weight: 600;
+  border: 1px solid #d0d0d0;
+  border-radius: 999px;
+  background: #fff;
+  color: #333;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-selector select:focus {
+  outline: none;
+  border-color: #0077b6;
+  box-shadow: 0 0 0 4px rgba(0, 119, 182, 0.15);
+}
+
+.language-selector::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 18px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #555;
+  border-bottom: 2px solid #555;
+  transform: translateY(-50%) rotate(45deg);
+  pointer-events: none;
 }
 
 /* Hero */
 .hero {
   position: relative;
+  width: 100%;
+  max-width: none;
+  margin: 0;
   background: url('../img/hero-bg.jpg') center/cover no-repeat;
-  height: 400px;
+  min-height: clamp(420px, 70vh, 560px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -57,19 +96,25 @@ header {
   position: relative;
   color: #fff;
   z-index: 1;
+  max-width: 720px;
+  padding: 0 20px;
 }
 
 .hero h1 {
   font-family: 'Montserrat', sans-serif;
-  font-size: 2rem;
+  font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 700;
+  line-height: 1.3;
 }
 
 /* Sections */
 section {
   padding: 60px 20px;
+}
+
+section:not(.hero) {
   max-width: 1000px;
-  margin: auto;
+  margin: 0 auto;
 }
 
 /* Events / Carousel */


### PR DESCRIPTION
## Summary
- make the hero section span the full viewport width with responsive sizing and centered copy
- polish the overall layout with a subtle body background and header spacing/shadow
- redesign the language selector with custom styling and focus states for a cleaner look

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3db40a18483308a5eea558596d8c3