### PR TITLE
Fix carousel layout to remove extra gap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,16 +131,27 @@ section:not(.hero) {
 }
 
 .slides {
-  display: flex;
-  transition: transform 0.5s ease-in-out;
+  position: relative;
 }
 
 .slide {
-  min-width: 100%;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
+.slide.active {
+  position: relative;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .slide img {
   width: 100%;
+  height: auto;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- update carousel slide styling so only the active image contributes to the layout, eliminating the tall gap before the event description
- add fade-ready opacity transitions and pointer handling for the carousel slides

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3e63f625883308703949fcc7731eb